### PR TITLE
fix: use cross-env for Windows compatibility in dev scripts

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "vinxi build",
     "serve": "vite preview",
     "test": "vitest run",
-    "dev": "PORT=3000 vinxi dev"
+    "dev": "cross-env PORT=3000 vinxi dev"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.17",


### PR DESCRIPTION
This pull request updates the `dev` scripts in the `package.json` files of the `frontend`, `fulfillment-api`, `products-api`, and `admin` apps to use `cross-env` for setting the `PORT` environment variable. This ensures compatibility with Windows systems.